### PR TITLE
Revert to default Accepts header

### DIFF
--- a/Source/rails.js
+++ b/Source/rails.js
@@ -123,7 +123,6 @@ window.addEvent('domready', function() {
         method: this.el.get('method') || this.el.get('data-method') || 'get',
         url: this.el.get('action') || this.el.get('href')
       }, options));
-      this.headers.Accept = '*/*';
 
       this.addRailsEvents();
     },


### PR DESCRIPTION
Hi Kevin, thanks for mootools-ujs!
I removed the overriding of the default Accepts header, since an Accepts header of only _/_ don't play well with respond_to. 
By default in Mootools the Accepts header is [text/javascript, text/html, application/xml, _/_] which lets respond_to :html, :js pick out the js template, but with Accepts _/_ it will respond with whatever the first is (:html in this case).

Was there a reason you put it there that I'm missing?

Cheers!
