### PR TITLE
Move domready to Bottom of File

### DIFF
--- a/Source/rails.js
+++ b/Source/rails.js
@@ -16,16 +16,6 @@ provides:
 ...
 */
 
-window.addEvent('domready', function() {
-
-  rails.csrf = {
-    token: rails.getCsrf('token'),
-    param: rails.getCsrf('param')
-  };
-
-  rails.applyEvents();
-});
-
 (function($) {
 
   window.rails = {
@@ -159,3 +149,12 @@ window.addEvent('domready', function() {
 
 })(document.id);
 
+window.addEvent('domready', function() {
+
+  rails.csrf = {
+    token: rails.getCsrf('token'),
+    param: rails.getCsrf('param')
+  };
+
+  rails.applyEvents();
+});


### PR DESCRIPTION
The [domready](http://mootools.net/docs/core/Utilities/DOMReady) event executes "when the DOM is loaded". When using an aysnchronous resource loader like [yepnope](http://yepnopejs.com/), the DOM might load before `rails.js` has loaded completely, causing a

```
rails is not defined
```

error to be thrown. Moving the `domready` event code to the bottom of the file guarantees `rails` is defined when called by the `domready` event.
