### PR TITLE
Remote POST/PUT/DELETE links add CSRF token to Request options

### DIFF
--- a/Source/rails.js
+++ b/Source/rails.js
@@ -128,9 +128,14 @@ window.addEvent('domready', function(){
     },
     
     send: function(options) {
+      var tag = this.el.get('tag');
       this.el.fireEvent('ajax:before');
-      if (this.el.get('tag') === 'form'){
+      if (tag === 'form'){
         this.options.data = this.el;
+      }
+      if (tag==='a'){
+        this.options.data = {};
+        this.options.data[rails.csrf.param] = rails.csrf.token;
       }
       this.parent(options);
       this.el.fireEvent('ajax:after', this.xhr);


### PR DESCRIPTION
Resolves [Issue #8](https://github.com/kevinvaldek/mootools-ujs/issues/8) by adding CSRF token before sending a remote link request when the link possesses a data-method attribute.
