### PR TITLE
Cancel link click if the user cancelled the confirmation request

### DIFF
--- a/Source/rails.js
+++ b/Source/rails.js
@@ -69,8 +69,12 @@ window.addEvent('domready', function(){
         }
       });
       var noMethodNorRemoteConfirm = ':not([data-method]):not([data-remote=true])[data-confirm]';
-      apply('a' + noMethodNorRemoteConfirm + ',' + 'input' + noMethodNorRemoteConfirm, 'click', function(){
-        return rails.confirmed(this);
+      apply('a' + noMethodNorRemoteConfirm + ',' + 'input' + noMethodNorRemoteConfirm, 'click', function(event){
+        var confirmed = rails.confirmed(this);
+        if (!confirmed) {
+          event.preventDefault();
+        }
+        return confirmed;
       });
     },
     


### PR DESCRIPTION
On a standard link with a data-confirm attribute, we want to ensure that the click event is cancelled if the user cancels the confirmation.
