### PR TITLE
Also send CSRF token for requests triggered from links

### DIFF
--- a/Source/rails.js
+++ b/Source/rails.js
@@ -128,9 +128,13 @@ window.addEvent('domready', function(){
     },
     
     send: function(options) {
+      var tag = this.el.get('tag');
       this.el.fireEvent('ajax:before');
-      if (this.el.get('tag') === 'form'){
+      if (tag === 'form'){
         this.options.data = this.el;
+      } else if (tag === 'a'){
+        this.options.data = {};
+        this.options.data[rails.csrf.param] = rails.csrf.token;
       }
       this.parent(options);
       this.el.fireEvent('ajax:after', this.xhr);


### PR DESCRIPTION
Ensure that the CSRF token is sent for forms submitted from links as well as actual forms.
