### PR TITLE
Turbolinks support added

### DIFF
--- a/Source/rails.js
+++ b/Source/rails.js
@@ -18,14 +18,14 @@ provides:
 */
 
 (function($){
-  domReadyCallback = function(){
+  var domReadyCallback = function(){
     rails.csrf = {
       token: rails.getCsrf('token'),
       param: rails.getCsrf('param')
     };
   
     rails.applyEvents();
-  }
+  };
   window.addEvent('domready', domReadyCallback);
   document.addEventListener('page:load', domReadyCallback);
 

--- a/Source/rails.js
+++ b/Source/rails.js
@@ -17,25 +17,25 @@ provides:
 ...
 */
 
-(function($){
-  var domReadyCallback = function(){
-    rails.csrf = {
-      token: rails.getCsrf('token'),
-      param: rails.getCsrf('param')
-    };
+window.addEvent('domready', function(){
   
-    rails.applyEvents();
+  rails.csrf = {
+    token: rails.getCsrf('token'),
+    param: rails.getCsrf('param')
   };
-  window.addEvent('domready', domReadyCallback);
-  document.addEventListener('page:load', domReadyCallback);
+  
+  rails.applyEvents();
+});
 
+(function($){
+  
   window.rails = {
     /**
      * If el is passed as argument, events will only be applied to
      * elements within el. Otherwise applied to document body.
      */
     applyEvents: function(el){
-      el = $(el || document.body);
+      el = $(el || document);
       var apply = function(selector, action, callback){
         el.addEvent(action + ':relay(' + selector + ')', callback);
       };

--- a/Source/rails.js
+++ b/Source/rails.js
@@ -17,18 +17,18 @@ provides:
 ...
 */
 
-window.addEvent('domready', function(){
-  
-  rails.csrf = {
-    token: rails.getCsrf('token'),
-    param: rails.getCsrf('param')
-  };
-  
-  rails.applyEvents();
-});
-
 (function($){
+  domReadyCallback = function(){
+    rails.csrf = {
+      token: rails.getCsrf('token'),
+      param: rails.getCsrf('param')
+    };
   
+    rails.applyEvents();
+  }
+  window.addEvent('domready', domReadyCallback);
+  document.addEventListener('page:load', domReadyCallback);
+
   window.rails = {
     /**
      * If el is passed as argument, events will only be applied to


### PR DESCRIPTION
Turbolinks replaces `document.body` so the relay doesn't work any more. This fix adds support for Turbolinks and has now drawbacks for websites without Turbolinks.
